### PR TITLE
Mirror of phadej postgresql-simple#46

### DIFF
--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -123,6 +123,7 @@ import qualified Data.Aeson.Parser as JSON (value')
 import           Data.Attoparsec.ByteString.Char8 hiding (Result)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
+import           Data.Functor.Identity (Identity(Identity))
 import           Data.Int (Int16, Int32, Int64)
 import           Data.IORef (IORef, newIORef)
 import           Data.Ratio (Ratio)
@@ -152,10 +153,6 @@ import           Data.UUID.Types   (UUID)
 import qualified Data.UUID.Types as UUID
 import           Data.Scientific (Scientific)
 import           GHC.Real (infinity, notANumber)
-
-#if MIN_VERSION_base(4,8,0)
-import           Data.Functor.Identity (Identity(Identity))
-#endif
 
 #if MIN_VERSION_base(4,9,0)
 #else
@@ -285,10 +282,8 @@ instance (FromField a) => FromField (Const a (b :: Type)) where
   fromField f bs = Const <$> fromField f bs
 #endif
 
-#if MIN_VERSION_base(4,8,0)
 instance (FromField a) => FromField (Identity a) where
   fromField f bs = Identity <$> fromField f bs
-#endif
 
 -- | For dealing with null values.  Compatible with any postgresql type
 --   compatible with type @a@.  Note that the type is not checked if

--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE FlexibleInstances, TypeSynonymInstances #-}
 {-# LANGUAGE PatternGuards, ScopedTypeVariables      #-}
 {-# LANGUAGE RecordWildCards                         #-}
-{-# LANGUAGE StandaloneDeriving, DerivingStrategies, KindSignatures, PolyKinds, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures, PolyKinds #-}
 
 {- |
 Module:      Database.PostgreSQL.Simple.FromField
@@ -124,6 +124,7 @@ import           Data.Attoparsec.ByteString.Char8 hiding (Result)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
 import           Data.Functor.Const (Const(Const))
+import           Data.Functor.Identity (Identity(Identity))
 import           Data.Int (Int16, Int32, Int64)
 import           Data.IORef (IORef, newIORef)
 import           Data.Ratio (Ratio)
@@ -269,7 +270,11 @@ instance FromField () where
      | typeOid f /= TI.voidOid = returnError Incompatible f ""
      | otherwise = pure ()
 
-deriving newtype instance (FromField a) => FromField (Const a (b :: k))
+instance (FromField a) => FromField (Const a (b :: k)) where
+  fromField f bs = Const <$> fromField f bs
+
+instance (FromField a) => FromField (Identity a) where
+  fromField f bs = Identity <$> fromField f bs
 
 -- | For dealing with null values.  Compatible with any postgresql type
 --   compatible with type @a@.  Note that the type is not checked if

--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -123,7 +123,6 @@ import qualified Data.Aeson.Parser as JSON (value')
 import           Data.Attoparsec.ByteString.Char8 hiding (Result)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
-import           Data.Functor.Const (Const(Const))
 import           Data.Functor.Identity (Identity(Identity))
 import           Data.Int (Int16, Int32, Int64)
 import           Data.IORef (IORef, newIORef)
@@ -154,6 +153,9 @@ import           Data.UUID.Types   (UUID)
 import qualified Data.UUID.Types as UUID
 import           Data.Scientific (Scientific)
 import           GHC.Real (infinity, notANumber)
+#if MIN_VERSION_base(4,9,0)
+import           Data.Functor.Const (Const(Const))
+#endif
 
 -- | Exception thrown if conversion from a SQL value to a Haskell
 -- value fails.
@@ -270,8 +272,10 @@ instance FromField () where
      | typeOid f /= TI.voidOid = returnError Incompatible f ""
      | otherwise = pure ()
 
+#if MIN_VERSION_base(4,9,0)
 instance (FromField a) => FromField (Const a (b :: k)) where
   fromField f bs = Const <$> fromField f bs
+#endif
 
 instance (FromField a) => FromField (Identity a) where
   fromField f bs = Identity <$> fromField f bs

--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -114,7 +114,7 @@ module Database.PostgreSQL.Simple.FromField
 
 #include "MachDeps.h"
 
-import           Control.Applicative ( (<|>), (<$>), pure, (*>), (<*) )
+import           Control.Applicative ( Const(Const), (<|>), (<$>), pure, (*>), (<*) )
 import           Control.Concurrent.MVar (MVar, newMVar)
 import           Control.Exception (Exception)
 import qualified Data.Aeson as JSON
@@ -123,7 +123,6 @@ import qualified Data.Aeson.Parser as JSON (value')
 import           Data.Attoparsec.ByteString.Char8 hiding (Result)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
-import           Data.Functor.Identity (Identity(Identity))
 import           Data.Int (Int16, Int32, Int64)
 import           Data.IORef (IORef, newIORef)
 import           Data.Ratio (Ratio)
@@ -153,8 +152,14 @@ import           Data.UUID.Types   (UUID)
 import qualified Data.UUID.Types as UUID
 import           Data.Scientific (Scientific)
 import           GHC.Real (infinity, notANumber)
+
+#if MIN_VERSION_base(4,8,0)
+import           Data.Functor.Identity (Identity(Identity))
+#endif
+
 #if MIN_VERSION_base(4,9,0)
-import           Data.Functor.Const (Const(Const))
+#else
+#define Type *
 #endif
 
 -- | Exception thrown if conversion from a SQL value to a Haskell
@@ -275,10 +280,15 @@ instance FromField () where
 #if MIN_VERSION_base(4,9,0)
 instance (FromField a) => FromField (Const a (b :: k)) where
   fromField f bs = Const <$> fromField f bs
+#else
+instance (FromField a) => FromField (Const a (b :: Type)) where
+  fromField f bs = Const <$> fromField f bs
 #endif
 
+#if MIN_VERSION_base(4,8,0)
 instance (FromField a) => FromField (Identity a) where
   fromField f bs = Identity <$> fromField f bs
+#endif
 
 -- | For dealing with null values.  Compatible with any postgresql type
 --   compatible with type @a@.  Note that the type is not checked if

--- a/src/Database/PostgreSQL/Simple/FromField.hs
+++ b/src/Database/PostgreSQL/Simple/FromField.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances, TypeSynonymInstances #-}
 {-# LANGUAGE PatternGuards, ScopedTypeVariables      #-}
 {-# LANGUAGE RecordWildCards                         #-}
+{-# LANGUAGE StandaloneDeriving, DerivingStrategies, KindSignatures, PolyKinds, GeneralizedNewtypeDeriving #-}
 
 {- |
 Module:      Database.PostgreSQL.Simple.FromField
@@ -122,6 +123,7 @@ import qualified Data.Aeson.Parser as JSON (value')
 import           Data.Attoparsec.ByteString.Char8 hiding (Result)
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
+import           Data.Functor.Const (Const(Const))
 import           Data.Int (Int16, Int32, Int64)
 import           Data.IORef (IORef, newIORef)
 import           Data.Ratio (Ratio)
@@ -266,6 +268,8 @@ instance FromField () where
   fromField f _bs
      | typeOid f /= TI.voidOid = returnError Incompatible f ""
      | otherwise = pure ()
+
+deriving newtype instance (FromField a) => FromField (Const a (b :: k))
 
 -- | For dealing with null values.  Compatible with any postgresql type
 --   compatible with type @a@.  Note that the type is not checked if

--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP, DeriveDataTypeable, DeriveFunctor  #-}
 {-# LANGUAGE FlexibleInstances, TypeSynonymInstances #-}
-{-# LANGUAGE StandaloneDeriving, DerivingStrategies, KindSignatures, PolyKinds, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures, PolyKinds #-}
 
 ------------------------------------------------------------------------------
 -- |
@@ -32,6 +32,7 @@ import           Data.ByteString.Builder
                    , floatDec, doubleDec
                    )
 import Data.Functor.Const (Const(Const))
+import Data.Functor.Identity (Identity(Identity))
 import Data.Int (Int8, Int16, Int32, Int64)
 import Data.List (intersperse)
 import Data.Monoid (mappend)
@@ -102,7 +103,13 @@ instance ToField Action where
     toField a = a
     {-# INLINE toField #-}
 
-deriving newtype instance (ToField a) => ToField (Const a (b :: k))
+instance (ToField a) => ToField (Const a (b :: k)) where
+  toField (Const a) = toField a
+  {-# INLINE toField #-}
+
+instance (ToField a) => ToField (Identity a) where
+  toField (Identity a) = toField a
+  {-# INLINE toField #-}
 
 instance (ToField a) => ToField (Maybe a) where
     toField Nothing  = renderNull

--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -31,7 +31,6 @@ import           Data.ByteString.Builder
                    , wordDec, word8Dec, word16Dec, word32Dec, word64Dec
                    , floatDec, doubleDec
                    )
-import Data.Functor.Const (Const(Const))
 import Data.Functor.Identity (Identity(Identity))
 import Data.Int (Int8, Int16, Int32, Int64)
 import Data.List (intersperse)
@@ -64,6 +63,9 @@ import           Data.Text.Lazy.Builder.Scientific (scientificBuilder)
 import           Data.Scientific (scientificBuilder)
 #endif
 import           Foreign.C.Types (CUInt(..))
+#if MIN_VERSION_base(4,9,0)
+import Data.Functor.Const (Const(Const))
+#endif
 
 -- | How to render an element when substituting it into a query.
 data Action =
@@ -103,9 +105,11 @@ instance ToField Action where
     toField a = a
     {-# INLINE toField #-}
 
+#if MIN_VERSION_base(4,9,0)
 instance (ToField a) => ToField (Const a (b :: k)) where
   toField (Const a) = toField a
   {-# INLINE toField #-}
+#endif
 
 instance (ToField a) => ToField (Identity a) where
   toField (Identity a) = toField a

--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP, DeriveDataTypeable, DeriveFunctor  #-}
 {-# LANGUAGE FlexibleInstances, TypeSynonymInstances #-}
+{-# LANGUAGE StandaloneDeriving, DerivingStrategies, KindSignatures, PolyKinds, GeneralizedNewtypeDeriving #-}
 
 ------------------------------------------------------------------------------
 -- |
@@ -30,6 +31,7 @@ import           Data.ByteString.Builder
                    , wordDec, word8Dec, word16Dec, word32Dec, word64Dec
                    , floatDec, doubleDec
                    )
+import Data.Functor.Const (Const(Const))
 import Data.Int (Int8, Int16, Int32, Int64)
 import Data.List (intersperse)
 import Data.Monoid (mappend)
@@ -99,6 +101,8 @@ class ToField a where
 instance ToField Action where
     toField a = a
     {-# INLINE toField #-}
+
+deriving newtype instance (ToField a) => ToField (Const a (b :: k))
 
 instance (ToField a) => ToField (Maybe a) where
     toField Nothing  = renderNull

--- a/src/Database/PostgreSQL/Simple/ToField.hs
+++ b/src/Database/PostgreSQL/Simple/ToField.hs
@@ -32,6 +32,7 @@ import           Data.ByteString.Builder
                    , wordDec, word8Dec, word16Dec, word32Dec, word64Dec
                    , floatDec, doubleDec
                    )
+import Data.Functor.Identity (Identity(Identity))
 import Data.Int (Int8, Int16, Int32, Int64)
 import Data.List (intersperse)
 import Data.Monoid (mappend)
@@ -63,10 +64,6 @@ import           Data.Text.Lazy.Builder.Scientific (scientificBuilder)
 import           Data.Scientific (scientificBuilder)
 #endif
 import           Foreign.C.Types (CUInt(..))
-
-#if MIN_VERSION_base(4,8,0)
-import Data.Functor.Identity (Identity(Identity))
-#endif
 
 #if MIN_VERSION_base(4,9,0)
 #else
@@ -121,11 +118,9 @@ instance (ToField a) => ToField (Const a (b :: Type)) where
   {-# INLINE toField #-}
 #endif
 
-#if MIN_VERSION_base(4,8,0)
 instance (ToField a) => ToField (Identity a) where
   toField (Identity a) = toField a
   {-# INLINE toField #-}
-#endif
 
 instance (ToField a) => ToField (Maybe a) where
     toField Nothing  = renderNull


### PR DESCRIPTION
Mirror of phadej postgresql-simple#46
As the description says, adds `ToField` and `FromField` instances for `Const` via `GeneralizedNewtypeDeriving`.

I ran `stylish-haskell` over the changed files as suggested by the `CONTRIBUTING.md` but it produced a much larger diff as I guess these files haven't been formatted by `stylish-haskell` in a while, if ever.
